### PR TITLE
Update upi_apps_helper.dart payzapp packagename to "com.hdfcbank.payz…

### DIFF
--- a/lib/upi_apps_helper.dart
+++ b/lib/upi_apps_helper.dart
@@ -196,7 +196,7 @@ class UpiAppsHelper {
       case _AllUpiApps.paywiz:
         return 'com.idbibank.paywiz';
       case _AllUpiApps.payZapp:
-        return "com.enstage.wibmo.hdfc";
+        return "com.hdfcbank.payzapp";
       case _AllUpiApps.phonePe:
         return 'com.phonepe.app';
       case _AllUpiApps.pnb:


### PR DESCRIPTION
…app"

The package name for payzapp has been updated from "com.enstage.wibmo.hdfc" to "com.hdfcbank.payzapp"